### PR TITLE
Added mu-plugins symlink creation.

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -41,6 +41,7 @@ if [[ ! -d "${VVV_PATH_TO_SITE}/public_html" ]]; then
 
   cd ${VVV_PATH_TO_SITE}/public_html/wp-content
   # Symlink the plugins and themes to the deafult install's plugins and themes
+  ln -s ../../../landlord/wp-content/mu-plugins mu-plugins
   ln -s ../../../landlord/wp-content/plugins plugins
   ln -s ../../../landlord/wp-content/themes themes
 


### PR DESCRIPTION
Especially helpful for developers, this creates a symlinked mu-plugin folder so that plugins within that folder activate on install and stay activated. Especially useful for something like Advanced Custom Fields or code to customize the color of the admin bar to indicate easily that you're on a local installation.